### PR TITLE
Add Check In/ Out Feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CheckClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CheckClientCommand.java
@@ -1,0 +1,79 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Checks In/ Out a specific Client in the MATER address book.
+ */
+public class CheckClientCommand extends Command {
+
+    public static final String COMMAND_WORD = "check-client";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Checks In/ Out a Client identified by the index number used in the displayed Clients list.\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_CHECK_IN_CLIENT_SUCCESS = "Checked In Client: %1$s";
+    public static final String MESSAGE_CHECK_OUT_CLIENT_SUCCESS = "Checked Out Client: %1$s";
+    public static final String MESSAGE_NO_CAR_TO_CHECK = "No Car associated to Client to Check In.";
+
+    private final Index targetIndex;
+
+    public CheckClientCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person clientToCheck = lastShownList.get(targetIndex.getZeroBased());
+
+        if (clientToCheck.getCar() == null) {
+            return new CommandResult(MESSAGE_NO_CAR_TO_CHECK);
+        }
+
+        clientToCheck.setServicing();
+        if (clientToCheck.isServicing()) {
+            return new CommandResult(String.format(MESSAGE_CHECK_IN_CLIENT_SUCCESS, Messages.format(clientToCheck)));
+        }
+        return new CommandResult(String.format(MESSAGE_CHECK_OUT_CLIENT_SUCCESS, Messages.format(clientToCheck)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CheckClientCommand)) {
+            return false;
+        }
+
+        CheckClientCommand otherCheckClientCommand = (CheckClientCommand) other;
+        return targetIndex.equals(otherCheckClientCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .add("targetIndex", targetIndex)
+            .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/CheckClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CheckClientCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
@@ -49,6 +50,8 @@ public class CheckClientCommand extends Command {
         }
 
         clientToCheck.setServicing();
+        model.setPerson(clientToCheck, clientToCheck); // Line required to update GUI.
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         if (clientToCheck.isServicing()) {
             return new CommandResult(String.format(MESSAGE_CHECK_IN_CLIENT_SUCCESS, Messages.format(clientToCheck)));
         }

--- a/src/main/java/seedu/address/logic/commands/CheckClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CheckClientCommand.java
@@ -20,9 +20,9 @@ public class CheckClientCommand extends Command {
     public static final String COMMAND_WORD = "check-client";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-        + ": Checks In/ Out a Client identified by the index number used in the displayed Clients list.\n"
-        + "Parameters: INDEX (must be a positive integer)\n"
-        + "Example: " + COMMAND_WORD + " 1";
+            + ": Checks In/ Out a Client identified by the index number used in the displayed Clients list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_CHECK_IN_CLIENT_SUCCESS = "Checked In Client: %1$s";
     public static final String MESSAGE_CHECK_OUT_CLIENT_SUCCESS = "Checked Out Client: %1$s";
@@ -76,7 +76,7 @@ public class CheckClientCommand extends Command {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .add("targetIndex", targetIndex)
-            .toString();
+                .add("targetIndex", targetIndex)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCarCommand;
 import seedu.address.logic.commands.AddClientCommand;
+import seedu.address.logic.commands.CheckClientCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteClientCommand;
@@ -55,6 +56,7 @@ public class AddressBookParser {
 
         switch (commandWord) {
 
+        // Client and Car Commands
         case AddClientCommand.COMMAND_WORD:
             return new AddClientCommandParser().parse(arguments);
 
@@ -64,26 +66,31 @@ public class AddressBookParser {
         case DeleteClientCommand.COMMAND_WORD:
             return new DeleteClientCommandParser().parse(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+        case AddCarCommand.COMMAND_WORD:
+            return new AddCarCommandParser().parse(arguments);
+
+        case CheckClientCommand.COMMAND_WORD:
+            return new CheckClientCommandParser().parse(arguments);
+
+        // GUI Commands
+        case ListClientCommand.COMMAND_WORD:
+            return new ListClientCommand();
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
 
-        case ListClientCommand.COMMAND_WORD:
-            return new ListClientCommand();
+        case ViewClientCommand.COMMAND_WORD:
+            return new ViewClientCommandParser().parse(arguments);
+
+        // Miscellaneous Commands.
+        case ClearCommand.COMMAND_WORD:
+            return new ClearCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
-
-        case ViewClientCommand.COMMAND_WORD:
-            return new ViewClientCommandParser().parse(arguments);
-
-        case AddCarCommand.COMMAND_WORD:
-            return new AddCarCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CheckClientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CheckClientCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CheckClientCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new CheckClientCommand object
+ */
+public class CheckClientCommandParser implements Parser<CheckClientCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the CheckClientCommand
+     * and returns a CheckClientCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public CheckClientCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new CheckClientCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CheckClientCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -29,6 +29,7 @@ public class Person {
     private final Car car;
 
     private final Set<Issue> issues = new HashSet<>();
+    private boolean isServicing;
 
     private final Logger logger = LogsCenter.getLogger(Person.class);
     /**
@@ -40,6 +41,7 @@ public class Person {
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.isServicing = false;
         this.issues.addAll(issues);
         this.car = null;
         logger.info("Person without car created");
@@ -60,6 +62,7 @@ public class Person {
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.isServicing = false;
         this.car = car;
         this.issues.addAll(issues);
         logger.info("Person with car created" + car);
@@ -91,6 +94,27 @@ public class Person {
      */
     public Set<Issue> getIssues() {
         return Collections.unmodifiableSet(issues);
+    }
+
+    /**
+     * Servicing status of a Client's Car.
+     *
+     * @return true if Checked in. False if not Checked in or no Car.
+     */
+    public boolean isServicing() {
+        if (this.car == null) {
+            return false; // Safeguard.
+        }
+        return this.isServicing;
+    }
+
+    /**
+     * Toggle isServicing for Clients with Car.
+     */
+    public void setServicing() {
+        if (this.car != null) {
+            this.isServicing = !this.isServicing;
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -114,6 +114,7 @@ public class Person {
     public void setServicing() {
         if (this.car != null) {
             this.isServicing = !this.isServicing;
+            logger.info("Client " + name + " has been " + (this.isServicing ? "Checked-In" : "Checked-Out"));
         }
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -57,6 +57,7 @@ class JsonAdaptedPerson {
             @JsonProperty("vrn") String vrn,
             @JsonProperty("make") String make,
             @JsonProperty("model") String model) {
+
         this.name = name;
         this.phone = phone;
         this.email = email;

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -34,6 +34,7 @@ class JsonAdaptedPerson {
     private final String phone;
     private final String email;
     private final String address;
+    private final String isServicing;
     private final String vin;
     private final String vrn;
     private final String make;
@@ -46,8 +47,11 @@ class JsonAdaptedPerson {
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
      */
     @JsonCreator
-    public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
-            @JsonProperty("email") String email, @JsonProperty("address") String address,
+    public JsonAdaptedPerson(@JsonProperty("name") String name,
+            @JsonProperty("phone") String phone,
+            @JsonProperty("email") String email,
+            @JsonProperty("address") String address,
+            @JsonProperty("isServicing") String isServicing,
             @JsonProperty("issues") List<JsonAdaptedIssue> issues,
             @JsonProperty("vin") String vin,
             @JsonProperty("vrn") String vrn,
@@ -57,6 +61,7 @@ class JsonAdaptedPerson {
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.isServicing = isServicing;
         this.vin = vin;
         this.vrn = vrn;
         this.make = make;
@@ -75,6 +80,7 @@ class JsonAdaptedPerson {
         phone = source.getPhone().value;
         email = source.getEmail().value;
         address = source.getAddress().value;
+        isServicing = Boolean.toString(source.isServicing());
         if (source.getCar() != null) {
             vin = source.getCar().getVin().toString();
             vrn = source.getCar().getVrn().toString();
@@ -134,6 +140,15 @@ class JsonAdaptedPerson {
         }
         final Address modelAddress = new Address(address);
 
+        final boolean modelIsServicing;
+        boolean temp;
+        try {
+            temp = Boolean.parseBoolean(isServicing);
+        } catch (Exception e){
+            temp = false;
+        }
+        modelIsServicing = temp;
+
         final Set<Issue> modelIssues = new HashSet<>(personIssues);
 
 
@@ -146,7 +161,11 @@ class JsonAdaptedPerson {
 
         // If all car details are present and valid, return a person with a car
         final Car car = new Car(new Vrn(vrn), new Vin(vin), new CarMake(make), new CarModel(model));
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelIssues, car);
+        Person client = new Person(modelName, modelPhone, modelEmail, modelAddress, modelIssues, car);
+        if (modelIsServicing) {
+            client.setServicing();
+        }
+        return client;
     }
 
     public void checkForMissingCarField() throws IllegalValueException {

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -144,7 +144,7 @@ class JsonAdaptedPerson {
         boolean temp;
         try {
             temp = Boolean.parseBoolean(isServicing);
-        } catch (Exception e){
+        } catch (Exception e) {
             temp = false;
         }
         modelIsServicing = temp;

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -2,7 +2,6 @@ package seedu.address.ui;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Person;

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -2,6 +2,7 @@ package seedu.address.ui;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Person;
@@ -21,7 +22,7 @@ public class PersonCard extends UiPart<Region> {
      * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
      */
 
-    public final Person person;
+    public final Person client;
 
     @FXML
     private HBox cardPane;
@@ -31,6 +32,8 @@ public class PersonCard extends UiPart<Region> {
     private Label name;
     @FXML
     private Label vrn;
+    @FXML
+    private Label isServicing;
 
 
     /**
@@ -38,11 +41,15 @@ public class PersonCard extends UiPart<Region> {
      */
     public PersonCard(Person person, int displayedIndex) {
         super(FXML);
-        this.person = person;
+
+        this.client = person;
         id.setText(Integer.toString(displayedIndex));
         name.setText(person.getName().fullName);
-        if (this.person.getCar() != null) {
+        if (this.client.getCar() != null) {
             vrn.setText(person.getCar().getVrn().vrn);
+        }
+        if (!client.isServicing()) {
+            isServicing.setVisible(false);
         }
     }
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -34,7 +34,6 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label isServicing;
 
-
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
@@ -47,8 +46,6 @@ public class PersonCard extends UiPart<Region> {
         if (this.client.getCar() != null) {
             vrn.setText(person.getCar().getVrn().vrn);
         }
-        if (!client.isServicing()) {
-            isServicing.setVisible(false);
-        }
+        isServicing.setVisible(client.isServicing());
     }
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -135,6 +135,21 @@
     -fx-text-fill: #FFFFFF;
 }
 
+.isServicing_label {
+    -fx-hgap: 10;
+    -fx-vgap: 10;
+    -fx-padding: 5px 5px 5px 5px;
+    -fx-background-color: #573088;
+    -fx-background-radius: 10;
+    -fx-font-size: 13px;
+}
+
+.isServicing_label:hover {
+    -fx-background-color: #472078;
+    -fx-scale-x: 1.05;
+    -fx-scale-y: 1.05;
+}
+
 
 /* The Enter Command Here Container Styling */
 .stack-pane {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -111,11 +111,6 @@
     -fx-background-color: #2c3451;
 }
 
-.list-cell:filled:selected #cardPane {
-    -fx-border-color: #2c3451;
-    -fx-border-width: 1;
-}
-
 .list-cell .label {
     -fx-text-fill: white;
 }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -3,9 +3,9 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
@@ -20,9 +20,13 @@
       <HBox spacing="0.5" alignment="CENTER_LEFT">
         <Label fx:id="id" styleClass="cell_index_label" />
         <VBox>
+          <padding>
+            <Insets right="15"/>
+          </padding>
           <Label fx:id="name" text="\$first" styleClass="cell_field_label" />
           <Label fx:id="vrn" text="No Car associated to Client" styleClass="cell_field_label"/>
         </VBox>
+        <Label fx:id="isServicing" text="Checked-In" styleClass="isServicing_label"/>
       </HBox>
     </VBox>
   </GridPane>

--- a/src/test/java/seedu/address/logic/commands/CheckClientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CheckClientCommandTest.java
@@ -1,0 +1,127 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code CheckClientCommand}.
+ */
+public class CheckClientCommandTest {
+
+    private static final CommandResult expectedNoCarToCheckMessage = new CommandResult(
+        CheckClientCommand.MESSAGE_NO_CAR_TO_CHECK);
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    /**
+     * Helper class to execute and test a CheckClientCommand given a client.
+     * @param clientToCheck The client to Check in/ out.
+     * @param index The index of the client to Check in/ out.
+     */
+    public void checkClientTestHelper(Person clientToCheck, Index index) {
+        CommandResult expectedCheckInResult = new CommandResult(
+                String.format(CheckClientCommand.MESSAGE_CHECK_IN_CLIENT_SUCCESS,
+                Messages.format(clientToCheck)));
+        CommandResult expectedCheckOutResult = new CommandResult(
+                String.format(CheckClientCommand.MESSAGE_CHECK_OUT_CLIENT_SUCCESS,
+                Messages.format(clientToCheck)));
+
+        CheckClientCommand checkClientCommand = new CheckClientCommand(index);
+        try {
+            if (clientToCheck.getCar() == null) {
+                assertEquals(expectedNoCarToCheckMessage, checkClientCommand.execute(model));
+                return;
+            }
+            clientToCheck.setServicing();
+            if (clientToCheck.isServicing()) {
+                assertEquals(expectedCheckInResult, checkClientCommand.execute(model));
+                return;
+            }
+            assertEquals(expectedCheckOutResult, checkClientCommand.execute(model));
+        } catch (CommandException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Person clientToCheck = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        checkClientTestHelper(clientToCheck, INDEX_FIRST_PERSON);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        CheckClientCommand checkClientCommand = new CheckClientCommand(outOfBoundIndex);
+
+        assertCommandFailure(checkClientCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Person clientToCheck = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        checkClientTestHelper(clientToCheck, INDEX_FIRST_PERSON);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        CheckClientCommand checkClientCommand = new CheckClientCommand(outOfBoundIndex);
+
+        assertCommandFailure(checkClientCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        CheckClientCommand checkFirstCommand = new CheckClientCommand(INDEX_FIRST_PERSON);
+        CheckClientCommand checkSecondCommand = new CheckClientCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(checkFirstCommand.equals(checkFirstCommand));
+
+        // same values -> returns true
+        CheckClientCommand checkFirstCommandCopy = new CheckClientCommand(INDEX_FIRST_PERSON);
+        assertTrue(checkFirstCommand.equals(checkFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(checkFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(checkFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(checkFirstCommand.equals(checkSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        CheckClientCommand checkClientCommand = new CheckClientCommand(targetIndex);
+        String expected = CheckClientCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, checkClientCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CheckClientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CheckClientCommandTest.java
@@ -27,7 +27,7 @@ import seedu.address.model.person.Person;
 public class CheckClientCommandTest {
 
     private static final CommandResult expectedNoCarToCheckMessage = new CommandResult(
-        CheckClientCommand.MESSAGE_NO_CAR_TO_CHECK);
+            CheckClientCommand.MESSAGE_NO_CAR_TO_CHECK);
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 

--- a/src/test/java/seedu/address/logic/commands/EditClientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditClientCommandTest.java
@@ -14,8 +14,8 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypiAddressBookAllWithCars;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBookAllWithCars;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -40,7 +40,7 @@ import seedu.address.testutil.PersonBuilder;
  */
 public class EditClientCommandTest {
 
-    private Model model = new ModelManager(getTypiAddressBookAllWithCars(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBookAllWithCars(), new UserPrefs());
     private Model modelWithoutCar = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddClientCommand;
+import seedu.address.logic.commands.CheckClientCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteClientCommand;
 import seedu.address.logic.commands.EditClientCommand;
@@ -36,7 +37,7 @@ public class AddressBookParserTest {
     private final AddressBookParser parser = new AddressBookParser();
 
     @Test
-    public void parseCommand_add() throws Exception {
+    public void parseCommand_addClient() throws Exception {
         Person person = new PersonBuilder().build();
         AddClientCommand command = (AddClientCommand) parser.parseCommand(PersonUtil.getAddClientCommand(person));
         assertEquals(new AddClientCommand(person), command);
@@ -49,14 +50,21 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_delete() throws Exception {
+    public void parseCommand_deleteClient() throws Exception {
         DeleteClientCommand command = (DeleteClientCommand) parser.parseCommand(
                 DeleteClientCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteClientCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test
-    public void parseCommand_edit() throws Exception {
+    public void parseCommand_checkClient() throws Exception {
+        CheckClientCommand command = (CheckClientCommand) parser.parseCommand(
+            CheckClientCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new CheckClientCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_editClient() throws Exception {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditClientCommand command = (EditClientCommand) parser.parseCommand(EditClientCommand.COMMAND_WORD + " "

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -59,7 +59,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_checkClient() throws Exception {
         CheckClientCommand command = (CheckClientCommand) parser.parseCommand(
-            CheckClientCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+                CheckClientCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new CheckClientCommand(INDEX_FIRST_PERSON), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/CheckClientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CheckClientCommandParserTest.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.CheckClientCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the CheckClientCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the CheckClientCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class CheckClientCommandParserTest {
+
+    private CheckClientCommandParser parser = new CheckClientCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsCheckClientCommand() {
+        assertParseSuccess(parser, "1", new CheckClientCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        String[] possibleInvalidUserInput = {"a", " ", "*", "a 1"};
+        for (String input : possibleInvalidUserInput) {
+            assertParseFailure(parser, input,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CheckClientCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/CheckClientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CheckClientCommandParserTest.java
@@ -30,7 +30,7 @@ public class CheckClientCommandParserTest {
         String[] possibleInvalidUserInput = {"a", " ", "*", "a 1"};
         for (String input : possibleInvalidUserInput) {
             assertParseFailure(parser, input,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CheckClientCommand.MESSAGE_USAGE));
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CheckClientCommand.MESSAGE_USAGE));
         }
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -135,4 +135,36 @@ public class PersonTest {
                                                     + ", car=" + aliceWithCar.getCar() + "}";
         assertEquals(expected, aliceWithCar.toString());
     }
+
+    @Test
+    public void checkInOutTest() {
+        // New clients are not automatically Checked in.
+        Person alice = new PersonBuilder(ALICE).build();
+        Person bob = new PersonBuilder(BOB).build();
+        assertFalse(alice.isServicing());
+        assertFalse(bob.isServicing());
+
+        // Clients with no Car cannot be Checked in.
+        alice.setServicing();
+        bob.setServicing();
+        assertFalse(alice.isServicing());
+        assertFalse(bob.isServicing());
+
+        alice = new PersonBuilder(alice).withCar("SJH9514P", "KMHGH4JH3EU073801", "Hyundai", "Kona 1.6T").build();
+        bob = new PersonBuilder(bob).withCar("S6780S", "ABCDE12345ABCDE12", "BMW", "520i").build();
+
+        // Clients with Car can be Checked in/ out indefinitely.
+        for (int i = 0; i < 10; i++) {
+            // Clients with Car whom are Checked out can be Checked in.
+            alice.setServicing();
+            bob.setServicing();
+            assertTrue(alice.isServicing());
+            assertTrue(bob.isServicing());
+            // Clients with Car whom are Checked in can be Checked out.
+            alice.setServicing();
+            bob.setServicing();
+            assertFalse(alice.isServicing());
+            assertFalse(bob.isServicing());
+        }
+    }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -1,6 +1,8 @@
 package seedu.address.storage;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_CAR_MAKE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_CAR_MODEL;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_CAR_VIN_0;

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -104,7 +104,7 @@ public class JsonAdaptedPersonTest {
     }
 
     @Test
-    public void toModelType_invalidIsServicing_throwsIllegalValueException() {
+    public void toModelType_invalidIsServicing_setBooleanToFalse() {
         // Corrects the invalid isServicing field to false by default.
         JsonAdaptedPerson personJson = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                 INVALID_IS_SERVICING, VALID_ISSUES, null, null, null, null);
@@ -117,10 +117,10 @@ public class JsonAdaptedPersonTest {
     }
 
     @Test
-    public void toModelType_nullIsServicing_throwsIllegalValueException() {
+    public void toModelType_nullIsServicing_setBooleanToFalse() {
         // Corrects the missing isServicing field to false by default.
         JsonAdaptedPerson personJson = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-            null, VALID_ISSUES, null, null, null, null);
+                null, VALID_ISSUES, null, null, null, null);
         try {
             Person person = personJson.toModelType();
             assertFalse(((Person) person).isServicing());

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -1,6 +1,6 @@
 package seedu.address.storage;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_CAR_MAKE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_CAR_MODEL;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_CAR_VIN_0;
@@ -29,6 +29,7 @@ import seedu.address.model.car.Vrn;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 
 
@@ -37,12 +38,14 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
+    private static final String INVALID_IS_SERVICING = "lol";
     private static final String INVALID_ISSUE = "#friend";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
+    private static final String VALID_IS_SERVICING = Boolean.toString(false);
     private static final List<JsonAdaptedIssue> VALID_ISSUES = BENSON.getIssues().stream()
             .map(JsonAdaptedIssue::new)
             .collect(Collectors.toList());
@@ -65,7 +68,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_missingVin_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ISSUES, null, VALID_CAR_VRN_A, VALID_CAR_MAKE_A, VALID_CAR_MODEL_A);
+                VALID_IS_SERVICING, VALID_ISSUES, null, VALID_CAR_VRN_A,
+                VALID_CAR_MAKE_A, VALID_CAR_MODEL_A);
         String expectedMessage = String.format(MISSING_CAR_FIELD_MESSAGE_FORMAT, "Vin");
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -73,7 +77,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_missingVrn_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ISSUES, VALID_CAR_VIN_A, null, VALID_CAR_MAKE_A, VALID_CAR_MODEL_A);
+                VALID_IS_SERVICING, VALID_ISSUES, VALID_CAR_VIN_A, null,
+                VALID_CAR_MAKE_A, VALID_CAR_MODEL_A);
         String expectedMessage = String.format(MISSING_CAR_FIELD_MESSAGE_FORMAT, "Vrn");
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -81,7 +86,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_missingMake_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ISSUES, VALID_CAR_VIN_A, VALID_CAR_VRN_A, null, VALID_CAR_MODEL_A);
+                VALID_IS_SERVICING, VALID_ISSUES, VALID_CAR_VIN_A, VALID_CAR_VRN_A,
+                null, VALID_CAR_MODEL_A);
         String expectedMessage = String.format(MISSING_CAR_FIELD_MESSAGE_FORMAT, "CarMake");
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -89,9 +95,36 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_missingModel_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ISSUES, VALID_CAR_VIN_A, VALID_CAR_VRN_A, VALID_CAR_MAKE_A, null);
+                VALID_IS_SERVICING, VALID_ISSUES, VALID_CAR_VIN_A, VALID_CAR_VRN_A,
+                VALID_CAR_MAKE_A, null);
         String expectedMessage = String.format(MISSING_CAR_FIELD_MESSAGE_FORMAT, "CarModel");
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidIsServicing_throwsIllegalValueException() {
+        // Corrects the invalid isServicing field to false by default.
+        JsonAdaptedPerson personJson = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                INVALID_IS_SERVICING, VALID_ISSUES, null, null, null, null);
+        try {
+            Person person = personJson.toModelType();
+            assertFalse(((Person) person).isServicing());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void toModelType_nullIsServicing_throwsIllegalValueException() {
+        // Corrects the missing isServicing field to false by default.
+        JsonAdaptedPerson personJson = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+            null, VALID_ISSUES, null, null, null, null);
+        try {
+            Person person = personJson.toModelType();
+            assertFalse(((Person) person).isServicing());
+        } catch (Exception e) {
+            fail();
+        }
     }
 
     /*
@@ -100,7 +133,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidVin_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ISSUES, INVALID_CAR_VIN_0, VALID_CAR_VRN_A, VALID_CAR_MAKE_A, VALID_CAR_MODEL_A);
+                VALID_IS_SERVICING, VALID_ISSUES, INVALID_CAR_VIN_0, VALID_CAR_VRN_A,
+                VALID_CAR_MAKE_A, VALID_CAR_MODEL_A);
         String expectedMessage = Vin.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -108,7 +142,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidVrn_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                    VALID_ISSUES, VALID_CAR_VIN_A, INVALID_CAR_VRN_0, VALID_CAR_MAKE_A, VALID_CAR_MODEL_A);
+                VALID_IS_SERVICING, VALID_ISSUES, VALID_CAR_VIN_A, INVALID_CAR_VRN_0,
+                VALID_CAR_MAKE_A, VALID_CAR_MODEL_A);
         String expectedMessage = Vrn.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -116,7 +151,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidMake_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-            VALID_ISSUES, VALID_CAR_VIN_A, VALID_CAR_VRN_A, INVALID_CAR_MAKE, VALID_CAR_MODEL_A);
+                VALID_IS_SERVICING, VALID_ISSUES, VALID_CAR_VIN_A, VALID_CAR_VRN_A,
+                INVALID_CAR_MAKE, VALID_CAR_MODEL_A);
         String expectedMessage = CarMake.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -124,7 +160,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidModel_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-            VALID_ISSUES, VALID_CAR_VIN_A, VALID_CAR_VRN_A, VALID_CAR_MAKE_A, INVALID_CAR_MODEL);
+                VALID_IS_SERVICING, VALID_ISSUES, VALID_CAR_VIN_A, VALID_CAR_VRN_A,
+                VALID_CAR_MAKE_A, INVALID_CAR_MODEL);
         String expectedMessage = CarModel.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -135,8 +172,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_ISSUES,
-                        null, null, null, null);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_IS_SERVICING, VALID_ISSUES, null, null, null, null);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -144,7 +181,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ISSUES, null, null, null, null);
+                VALID_IS_SERVICING, VALID_ISSUES, null, null, null, null);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -152,8 +189,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_ISSUES,
-                        null, null, null, null);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_IS_SERVICING, VALID_ISSUES, null, null, null, null);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -161,7 +198,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ISSUES, null, null, null, null);
+                VALID_IS_SERVICING, VALID_ISSUES, null, null, null, null);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -169,8 +206,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_ISSUES,
-                        null, null, null, null);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_IS_SERVICING,
+                        VALID_ISSUES, null, null, null, null);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -178,7 +215,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_ISSUES, null, null, null, null);
+                VALID_IS_SERVICING, VALID_ISSUES, null, null, null, null);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -187,15 +224,15 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
-                        VALID_ISSUES, null, null, null, null);
+                        VALID_IS_SERVICING, VALID_ISSUES, null, null, null, null);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_ISSUES,
-                null, null, null, null);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
+                VALID_IS_SERVICING, VALID_ISSUES, null, null, null, null);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -205,8 +242,8 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedIssue> invalidIssues = new ArrayList<>(VALID_ISSUES);
         invalidIssues.add(new JsonAdaptedIssue(INVALID_ISSUE));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidIssues,
-                        null, null, null, null);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_IS_SERVICING, invalidIssues, null, null, null, null);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -111,7 +111,7 @@ public class TypicalPersons {
         return ab;
     }
 
-    public static AddressBook getTypiAddressBookAllWithCars() {
+    public static AddressBook getTypicalAddressBookAllWithCars() {
         AddressBook ab = new AddressBook();
         for (Person person : getTypicalPersonsAllWithCars()) {
             ab.addPerson(person);


### PR DESCRIPTION
Fixes #117 

## Design Decision
1. New Clients *(add-client)* will not be checked in automatically.
2. Clients without Cars are not allowed to check-in.
3. Checked-in Clients should not have their Cars deleted *(delete-car)* **(to be implemented by Tahir)**.
4. **(Future Implementation TBC)** List clients who are currently checked-in *(list-checkedin)* **(to be implemented by Sean)**.

## GUI for Check Client
### Clients who are Checked In will have a tag, else no tag.
<img width="742" alt="Screenshot 2024-10-20 at 6 21 14 AM" src="https://github.com/user-attachments/assets/3c93415e-b7fe-4648-8c7c-a6d97adf9aaa">
