### PR TITLE
Update Result Display

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -12,10 +12,10 @@ import seedu.address.model.person.Person;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command.";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The Client index provided is invalid.";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d Clients listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -63,4 +63,22 @@ public class Messages {
         return builder.toString();
     }
 
+    /**
+     * Formats the command success message for display to the user.
+     * If the user has a Car, include the VRN in the message.
+     */
+    public static String formatSuccessMessage(Person person, String successMessage) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(successMessage);
+        builder.append(": ");
+        builder.append(person.getName());
+        if (person.getCar() == null) {
+            builder.append(".");
+        } else {
+            builder.append("(VRN: ");
+            builder.append(person.getVrn());
+            builder.append(").");
+        }
+        return builder.toString();
+    }
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -75,7 +75,7 @@ public class Messages {
         if (person.getCar() == null) {
             builder.append(".");
         } else {
-            builder.append("(VRN: ");
+            builder.append(" (VRN: ");
             builder.append(person.getVrn());
             builder.append(").");
         }

--- a/src/main/java/seedu/address/logic/commands/AddCarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCarCommand.java
@@ -16,25 +16,28 @@ import seedu.address.model.car.Car;
 import seedu.address.model.person.Person;
 
 /**
- * Adds a Car to a person already present in the MATER address book.
+ * Adds a Car to a Client in the MATER address book.
  */
 public class AddCarCommand extends Command {
 
     public static final String COMMAND_WORD = "add-car";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Adds a new car to the client of the index provided, with the details provided by the user.\n"
-            + "User must not currently have a car.\n"
-            + "The index must be a positive integer. \n"
+            + ": Adds a Car to the indexed Client, who must not be associated to a Car.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_VRN + " VEHICLE REGISTRATION NUMBER "
+            + PREFIX_VIN + " VEHICLE IDENTIFICATION NUMBER "
+            + PREFIX_MAKE + " VEHICLE MAKE "
+            + PREFIX_MODEL + " VEHICLE MODEL\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_VRN + "SGX1234B "
+            + PREFIX_VRN + "SJH9514P "
             + PREFIX_VIN + "KMHGH4JH3EU073801 "
             + PREFIX_MAKE + "Toyota "
             + PREFIX_MODEL + "Corolla ";
 
-    public static final String MESSAGE_USER_ALREADY_HAS_CAR = "This person already has a car.";
-    public static final String MESSAGE_ADD_CAR_SUCCESS = "Car successfully added: %s";
-    public static final String MESSAGE_SAME_CAR_ALREADY_EXISTS = "This car already exists in the address book";
+    public static final String MESSAGE_USER_ALREADY_HAS_CAR = "Client is already associated to a Car.";
+    public static final String MESSAGE_ADD_CAR_SUCCESS = "Car successfully added to Client: %s (VRN: %s).";
+    public static final String MESSAGE_SAME_CAR_ALREADY_EXISTS = "Car already exists in MATER.";
 
     private final Index index;
     private final Car carToAdd;
@@ -83,7 +86,7 @@ public class AddCarCommand extends Command {
         // This method call effectively replaces the old user with the new user with a car.
         model.setPerson(personToAddCarTo, updatedPerson);
 
-        return new CommandResult(String.format(MESSAGE_ADD_CAR_SUCCESS, carToAdd));
+        return new CommandResult(String.format(MESSAGE_ADD_CAR_SUCCESS, updatedPerson.getName(), carToAdd.getVrn()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddCarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCarCommand.java
@@ -36,7 +36,7 @@ public class AddCarCommand extends Command {
             + PREFIX_MODEL + "Corolla ";
 
     public static final String MESSAGE_USER_ALREADY_HAS_CAR = "Client is already associated to a Car.";
-    public static final String MESSAGE_ADD_CAR_SUCCESS = "Car successfully added to Client: %s (VRN: %s).";
+    public static final String MESSAGE_ADD_CAR_SUCCESS = "Car successfully added to Client";
     public static final String MESSAGE_SAME_CAR_ALREADY_EXISTS = "Car already exists in MATER.";
 
     private final Index index;
@@ -86,7 +86,7 @@ public class AddCarCommand extends Command {
         // This method call effectively replaces the old user with the new user with a car.
         model.setPerson(personToAddCarTo, updatedPerson);
 
-        return new CommandResult(String.format(MESSAGE_ADD_CAR_SUCCESS, updatedPerson.getName(), carToAdd.getVrn()));
+        return new CommandResult(Messages.formatSuccessMessage(updatedPerson, MESSAGE_ADD_CAR_SUCCESS));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddClientCommand.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_VIN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VRN;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
@@ -44,8 +45,7 @@ public class AddClientCommand extends Command {
 
     public static final String VEHICLE_DETAILS_MISSING =
             "Vehicle details are missing. Please provide all vehicle details.\n" + MESSAGE_USAGE;
-    public static final String MESSAGE_SUCCESS = "New Client added to MATER: %s.";
-    public static final String MESSAGE_SUCCESS_WITH_CAR = "New Client added to MATER: %s (VRN: %s).";
+    public static final String MESSAGE_SUCCESS = "New Client added to MATER";
     public static final String MESSAGE_DUPLICATE_PERSON = "Client already exists in MATER.";
     public static final String MESSAGE_NO_CAR_TO_ADD_ISSUES = "Client does not have a Car to add Issues.";
 
@@ -78,12 +78,7 @@ public class AddClientCommand extends Command {
 
         model.addPerson(toAdd);
 
-        String message;
-        if (toAdd.getCar() == null) {
-            message = String.format(MESSAGE_SUCCESS, toAdd.getName());
-        } else {
-            message = String.format(MESSAGE_SUCCESS_WITH_CAR, toAdd.getName(), toAdd.getVrn());
-        }
+        String message = Messages.formatSuccessMessage(toAdd, MESSAGE_SUCCESS);
         return new CommandResult(message);
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddClientCommand.java
@@ -11,19 +11,18 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_VIN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VRN;
 
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
- * Adds a person to the MATER address book.
+ * Adds a Client to the MATER address book.
  */
 public class AddClientCommand extends Command {
 
     public static final String COMMAND_WORD = "add-client";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a client to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a Client to MATER. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
@@ -38,17 +37,17 @@ public class AddClientCommand extends Command {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_VRN + "SGX1234B "
+            + PREFIX_VRN + "SJH9514P "
             + PREFIX_VIN + "KMHGH4JH3EU073801 "
             + PREFIX_MAKE + "Toyota "
             + PREFIX_MODEL + "Corolla ";
 
     public static final String VEHICLE_DETAILS_MISSING =
-            "Vehicle details are missing. Please provide all vehicle details. \n" + MESSAGE_USAGE;
-    public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_SUCCESS_WITH_CAR = "with VIN: ";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
-    public static final String MESSAGE_NO_CAR_TO_ADD_ISSUES = "This person does not have a car to add issues to";
+            "Vehicle details are missing. Please provide all vehicle details.\n" + MESSAGE_USAGE;
+    public static final String MESSAGE_SUCCESS = "New Client added to MATER: %s.";
+    public static final String MESSAGE_SUCCESS_WITH_CAR = "New Client added to MATER: %s (VRN: %s).";
+    public static final String MESSAGE_DUPLICATE_PERSON = "Client already exists in MATER.";
+    public static final String MESSAGE_NO_CAR_TO_ADD_ISSUES = "Client does not have a Car to add Issues.";
 
     private final Person toAdd;
 
@@ -57,7 +56,6 @@ public class AddClientCommand extends Command {
      */
     public AddClientCommand(Person person) {
         requireNonNull(person);
-        System.out.println(person);
         toAdd = person;
     }
 
@@ -70,21 +68,22 @@ public class AddClientCommand extends Command {
         }
 
         if (model.hasCar(toAdd.getCar())) {
-            throw new CommandException("This car already exists in the address book");
+            throw new CommandException("Car already exists in MATER.");
         }
 
-        // check if there is a car to add issues to
-        if (toAdd.getCar() == null && toAdd.getIssues().size() > 0) {
+        // Check if there is a Car to add Issues to.
+        if (toAdd.getCar() == null && !toAdd.getIssues().isEmpty()) {
             throw new CommandException(MESSAGE_NO_CAR_TO_ADD_ISSUES);
         }
 
         model.addPerson(toAdd);
 
-        String message = String.format(MESSAGE_SUCCESS, Messages.format(toAdd));
-        if (toAdd.getCar() != null) {
-            message += MESSAGE_SUCCESS_WITH_CAR + Messages.formatCar(toAdd);
+        String message;
+        if (toAdd.getCar() == null) {
+            message = String.format(MESSAGE_SUCCESS, toAdd.getName());
+        } else {
+            message = String.format(MESSAGE_SUCCESS_WITH_CAR, toAdd.getName(), toAdd.getVrn());
         }
-
         return new CommandResult(message);
     }
 

--- a/src/main/java/seedu/address/logic/commands/CheckClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CheckClientCommand.java
@@ -20,12 +20,12 @@ public class CheckClientCommand extends Command {
     public static final String COMMAND_WORD = "check-client";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Checks In/ Out a Client identified by the index number used in the displayed Clients list.\n"
+            + ": Checks In/ Out the indexed Client.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_CHECK_IN_CLIENT_SUCCESS = "Checked In Client: %1$s";
-    public static final String MESSAGE_CHECK_OUT_CLIENT_SUCCESS = "Checked Out Client: %1$s";
+    public static final String MESSAGE_CHECK_IN_CLIENT_SUCCESS = "Checked In Client: %s (VRN: %s).";
+    public static final String MESSAGE_CHECK_OUT_CLIENT_SUCCESS = "Checked Out Client: %s (VRN: %s).";
     public static final String MESSAGE_NO_CAR_TO_CHECK = "No Car associated to Client to Check In.";
 
     private final Index targetIndex;
@@ -53,9 +53,11 @@ public class CheckClientCommand extends Command {
         model.setPerson(clientToCheck, clientToCheck); // Line required to update GUI.
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         if (clientToCheck.isServicing()) {
-            return new CommandResult(String.format(MESSAGE_CHECK_IN_CLIENT_SUCCESS, Messages.format(clientToCheck)));
+            return new CommandResult(String.format(MESSAGE_CHECK_IN_CLIENT_SUCCESS,
+                    clientToCheck.getName()));
         }
-        return new CommandResult(String.format(MESSAGE_CHECK_OUT_CLIENT_SUCCESS, Messages.format(clientToCheck)));
+        return new CommandResult(String.format(MESSAGE_CHECK_OUT_CLIENT_SUCCESS,
+                clientToCheck.getName(), clientToCheck.getVrn()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CheckClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CheckClientCommand.java
@@ -54,7 +54,7 @@ public class CheckClientCommand extends Command {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         if (clientToCheck.isServicing()) {
             return new CommandResult(String.format(MESSAGE_CHECK_IN_CLIENT_SUCCESS,
-                    clientToCheck.getName()));
+                    clientToCheck.getName(), clientToCheck.getVrn()));
         }
         return new CommandResult(String.format(MESSAGE_CHECK_OUT_CLIENT_SUCCESS,
                 clientToCheck.getName(), clientToCheck.getVrn()));

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -6,12 +6,12 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 
 /**
- * Clears the address book.
+ * Clears the MATER address book.
  */
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "MATER has been cleared!";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCarCommand.java
@@ -8,7 +8,6 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.car.Car;
 import seedu.address.model.person.Person;
 
 /**
@@ -19,15 +18,13 @@ public class DeleteCarCommand extends Command {
     public static final String COMMAND_WORD = "delete-car";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the car currently belonging to the client of the index provided.\n"
-            + "Client must already have a car. The index must be a positive integer.\n"
-            + "Client's car cannot be currently checked-in in order to be deleted.\n"
+            + ": Deletes the Car of the indexed Client, who must be associated to a Car.\n"
+            + "Car must not be Checked In.\n"
             + "Example: " + COMMAND_WORD + " 1 ";
 
-    public static final String MESSAGE_USER_IS_CHECKED_IN = "This person's car is currently checked in.";
-    public static final String MESSAGE_DELETE_CAR_SUCCESS =
-            "Car deleted successfully from index %s: VRN: %s, VIN: %s, Make: %s, Model: %s";
-    public static final String MESSAGE_USER_HAS_NO_CAR = "This person has no car to delete.";
+    public static final String MESSAGE_USER_IS_CHECKED_IN = "Car is currently Checked In.";
+    public static final String MESSAGE_DELETE_CAR_SUCCESS = "Car successfully deleted from Client";
+    public static final String MESSAGE_USER_HAS_NO_CAR = "Client is not associated to a Car.";
 
     private final Index index;
 
@@ -71,13 +68,10 @@ public class DeleteCarCommand extends Command {
                 personToDeleteCarFrom.getIssues()
         );
 
-        // This is to pass the details of the deleted car to the UI for visual confirmation.
-        Car carToDelete = personToDeleteCarFrom.getCar();
         // This method call effectively replaces the old user with the new user with a car.
         model.setPerson(personToDeleteCarFrom, updatedPerson);
 
-        return new CommandResult(String.format(MESSAGE_DELETE_CAR_SUCCESS, index.getOneBased(), carToDelete.getVrn(),
-                carToDelete.getVin(), carToDelete.getCarMake(), carToDelete.getCarModel()));
+        return new CommandResult(Messages.formatSuccessMessage(updatedPerson, MESSAGE_DELETE_CAR_SUCCESS));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteClientCommand.java
@@ -23,8 +23,7 @@ public class DeleteClientCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_CLIENT_SUCCESS = "Client deleted from MATER: %s.";
-    public static final String MESSAGE_DELETE_CLIENT_SUCCESS_WITH_CAR = "Client deleted from MATER: %s (VRN: %s).";
+    public static final String MESSAGE_DELETE_CLIENT_SUCCESS = "Client deleted from MATER";
 
     private final Index targetIndex;
 
@@ -44,13 +43,7 @@ public class DeleteClientCommand extends Command {
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
 
-        String message;
-        if (personToDelete.getCar() == null) {
-            message = String.format(MESSAGE_DELETE_CLIENT_SUCCESS, personToDelete.getName());
-        } else {
-            message = String.format(MESSAGE_DELETE_CLIENT_SUCCESS_WITH_CAR,
-                    personToDelete.getName(), personToDelete.getVrn());
-        }
+        String message = Messages.formatSuccessMessage(personToDelete, MESSAGE_DELETE_CLIENT_SUCCESS);
         return new CommandResult(message);
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteClientCommand.java
@@ -12,18 +12,19 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
- * Deletes a person identified using it's displayed index from the address book.
+ * Deletes a Client identified using it's displayed index from the MATER address book.
  */
 public class DeleteClientCommand extends Command {
 
     public static final String COMMAND_WORD = "delete-client";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
+            + ": Deletes the indexed Client.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_CLIENT_SUCCESS = "Client deleted from MATER: %s.";
+    public static final String MESSAGE_DELETE_CLIENT_SUCCESS_WITH_CAR = "Client deleted from MATER: %s (VRN: %s).";
 
     private final Index targetIndex;
 
@@ -42,7 +43,15 @@ public class DeleteClientCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+
+        String message;
+        if (personToDelete.getCar() == null) {
+            message = String.format(MESSAGE_DELETE_CLIENT_SUCCESS, personToDelete.getName());
+        } else {
+            message = String.format(MESSAGE_DELETE_CLIENT_SUCCESS_WITH_CAR,
+                    personToDelete.getName(), personToDelete.getVrn());
+        }
+        return new CommandResult(message);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditClientCommand.java
@@ -37,14 +37,14 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 
 /**
- * Edits the details of an existing person in the address book.
+ * Edits the details of an existing Client in the MATER address book.
  */
 public class EditClientCommand extends Command {
 
     public static final String COMMAND_WORD = "edit-client";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
-            + "by the index number used in the displayed person list. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Edits the details of the indexed client. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
@@ -57,13 +57,14 @@ public class EditClientCommand extends Command {
             + "[" + PREFIX_MODEL + "VEHICLE MODEL] "
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
-            + PREFIX_EMAIL + "johndoe@example.com";
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_CAR_DOES_NOT_EXIST = "This person does not have a car to edit.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
-    public static final String MESSAGE_DUPLICATE_CAR = "This car already exists in the address book.";
-    public static final String MESSAGE_NO_CAR_TO_EDIT_ISSUES = "This person does not have a car to edit issues to";
+            + PREFIX_VRN + "SNP5701C";
+    public static final String MESSAGE_EDIT_CLIENT_SUCCESS = "Edited Client in MATER: %s.";
+    public static final String MESSAGE_EDIT_CLIENT_SUCCESS_WITH_CAR = "Edited Client in MATER: %s (VRN: %s).";
+    public static final String MESSAGE_NOT_EDITED = "At least one field must be edited.";
+    public static final String MESSAGE_CAR_DOES_NOT_EXIST = "Client does not have a Car to edit.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "Client already exists in MATER.";
+    public static final String MESSAGE_DUPLICATE_CAR = "Car already exists in MATER.";
+    public static final String MESSAGE_NO_CAR_TO_EDIT_ISSUES = "Client does not have a Car to edit Issues.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -126,8 +127,16 @@ public class EditClientCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        System.out.println(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+
+        String message;
+        if (editedPerson.getCar() == null) {
+            message = String.format(MESSAGE_EDIT_CLIENT_SUCCESS,
+                    editedPerson.getName());
+        } else {
+            message = String.format(MESSAGE_EDIT_CLIENT_SUCCESS_WITH_CAR,
+                    editedPerson.getName(), editedPerson.getVrn());
+        }
+        return new CommandResult(message);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/EditClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditClientCommand.java
@@ -58,8 +58,7 @@ public class EditClientCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_VRN + "SNP5701C";
-    public static final String MESSAGE_EDIT_CLIENT_SUCCESS = "Edited Client in MATER: %s.";
-    public static final String MESSAGE_EDIT_CLIENT_SUCCESS_WITH_CAR = "Edited Client in MATER: %s (VRN: %s).";
+    public static final String MESSAGE_EDIT_CLIENT_SUCCESS = "Edited Client in MATER";
     public static final String MESSAGE_NOT_EDITED = "At least one field must be edited.";
     public static final String MESSAGE_CAR_DOES_NOT_EXIST = "Client does not have a Car to edit.";
     public static final String MESSAGE_DUPLICATE_PERSON = "Client already exists in MATER.";
@@ -128,14 +127,7 @@ public class EditClientCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        String message;
-        if (editedPerson.getCar() == null) {
-            message = String.format(MESSAGE_EDIT_CLIENT_SUCCESS,
-                    editedPerson.getName());
-        } else {
-            message = String.format(MESSAGE_EDIT_CLIENT_SUCCESS_WITH_CAR,
-                    editedPerson.getName(), editedPerson.getVrn());
-        }
+        String message = Messages.formatSuccessMessage(editedPerson, MESSAGE_EDIT_CLIENT_SUCCESS);
         return new CommandResult(message);
     }
 

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -3,13 +3,13 @@ package seedu.address.logic.commands;
 import seedu.address.model.Model;
 
 /**
- * Terminates the program.
+ * Terminates the MATER program.
  */
 public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting MATER as requested ...";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -8,18 +8,17 @@ import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Finds and lists all Clients in the MATER address book whose name or vrn contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names or "
-            + "car VRN numbers contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all Clients whose names or "
+            + "car VRN contain any of the specified keywords (case-insensitive)\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice SGX1234B";
+            + "Example: " + COMMAND_WORD + " john SJH9514P";
 
     private final NameContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/ListClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListClientCommand.java
@@ -6,13 +6,13 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import seedu.address.model.Model;
 
 /**
- * Lists all clients in the MATER.
+ * Lists all Clients in the MATER.
  */
 public class ListClientCommand extends Command {
 
     public static final String COMMAND_WORD = "list-client";
 
-    public static final String MESSAGE_SUCCESS = "Listed all clients!";
+    public static final String MESSAGE_SUCCESS = "Listed all Clients!";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ViewClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewClientCommand.java
@@ -20,9 +20,7 @@ public class ViewClientCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
     public static final String MESSAGE_VIEW_CLIENT_SUCCESS =
-            "Mater - View Client window opened for: %s.";
-    public static final String MESSAGE_VIEW_CLIENT_SUCCESS_WITH_CAR =
-            "Mater - View Client window opened for: %s (VRN: %s).";
+            "Mater - View Client window opened for";
 
     private final Index index;
 
@@ -45,18 +43,8 @@ public class ViewClientCommand extends Command {
         }
 
         Person clientToView = lastShownList.get(index.getZeroBased());
-        String carDetails = clientToView.getCar() == null ? "No car details available" : "VRN: "
-                + clientToView.getCar().getVrn() + "\nVIN: " + clientToView.getCar().getVin() + "\nMake: "
-                + clientToView.getCar().getCarMake() + "\nModel: " + clientToView.getCar().getCarModel();
 
-        String message;
-        if (clientToView.getCar() == null) {
-            message = String.format(MESSAGE_VIEW_CLIENT_SUCCESS,
-                    clientToView.getName());
-        } else {
-            message = String.format(MESSAGE_VIEW_CLIENT_SUCCESS_WITH_CAR,
-                    clientToView.getName(), clientToView.getVrn());
-        }
+        String message = Messages.formatSuccessMessage(clientToView, MESSAGE_VIEW_CLIENT_SUCCESS);
         return new CommandResult(message, false, false, true, clientToView);
     }
 

--- a/src/main/java/seedu/address/logic/commands/ViewClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewClientCommand.java
@@ -11,17 +11,18 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
- * Views the details of an existing person in the address book.
+ * Displays the full details of an existing Client in the  MATER address book.
  */
 public class ViewClientCommand extends Command {
     public static final String COMMAND_WORD = "view-client";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Views the details of the client identified by the index number used in the displayed client list.\n"
+            + ": Displays the details of the indexed Client.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
-    public static final String MESSAGE_SUCCESS = "Client %1$s’s Details:\n"
-            + "H/P: %2$s\nEMAIL: %3$s\nADDRESS: %4$s\n%5$s";
-    public static final String MESSAGE_FAILURE = "Error! Please check if the client’s index is valid.";
+    public static final String MESSAGE_VIEW_CLIENT_SUCCESS =
+            "Mater - View Client window opened for: %s.";
+    public static final String MESSAGE_VIEW_CLIENT_SUCCESS_WITH_CAR =
+            "Mater - View Client window opened for: %s (VRN: %s).";
 
     private final Index index;
 
@@ -48,9 +49,15 @@ public class ViewClientCommand extends Command {
                 + clientToView.getCar().getVrn() + "\nVIN: " + clientToView.getCar().getVin() + "\nMake: "
                 + clientToView.getCar().getCarMake() + "\nModel: " + clientToView.getCar().getCarModel();
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, clientToView.getName(),
-                clientToView.getPhone(), clientToView.getEmail(), clientToView.getAddress(), carDetails),
-                false, false, true, clientToView);
+        String message;
+        if (clientToView.getCar() == null) {
+            message = String.format(MESSAGE_VIEW_CLIENT_SUCCESS,
+                    clientToView.getName());
+        } else {
+            message = String.format(MESSAGE_VIEW_CLIENT_SUCCESS_WITH_CAR,
+                    clientToView.getName(), clientToView.getVrn());
+        }
+        return new CommandResult(message, false, false, true, clientToView);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -11,6 +11,7 @@ import java.util.logging.Logger;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.car.Car;
+import seedu.address.model.car.Vrn;
 import seedu.address.model.issue.Issue;
 
 /**
@@ -86,6 +87,10 @@ public class Person {
 
     public Car getCar() {
         return car;
+    }
+
+    public Vrn getVrn() {
+        return this.getCar().getVrn();
     }
 
     /**

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -165,9 +165,10 @@
 
 .result-display {
     -fx-background-color: transparent;
-    -fx-font-family: "Segoe UI Light";
-    -fx-font-size: 13pt;
+    -fx-font-family: "Segoe UI";
+    -fx-font-size: 10pt;
     -fx-text-fill: white;
+    -fx-wrap-text: true;
 }
 
 .result-display .label {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -40,7 +40,7 @@
         </StackPane>
 
         <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
+                   minHeight="120" prefHeight="120" maxHeight="120">
           <padding>
             <Insets top="5" right="10" bottom="5" left="10" />
           </padding>

--- a/src/test/java/seedu/address/logic/commands/AddCarCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCarCommandTest.java
@@ -36,7 +36,7 @@ public class AddCarCommandTest {
     @Test
     public void execute_addCarToEligiblePerson_success() throws Exception {
         Person validPerson = new PersonBuilder().build();
-        Car validCar = new Car(new Vrn("SGX1234B"), new Vin("KMHGH4JH3EU073801"),
+        Car validCar = new Car(new Vrn("SJH9514P"), new Vin("KMHGH4JH3EU073801"),
                 new CarMake("Toyota"), new CarModel("Corolla"));
         ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
         modelStub.addPerson(validPerson); // Add person to the stub model
@@ -44,7 +44,8 @@ public class AddCarCommandTest {
         AddCarCommand addCarCommand = new AddCarCommand(Index.fromOneBased(1), validCar);
         CommandResult commandResult = addCarCommand.execute(modelStub);
 
-        assertEquals(String.format(AddCarCommand.MESSAGE_ADD_CAR_SUCCESS, validCar), commandResult.getFeedbackToUser());
+        assertEquals(String.format(AddCarCommand.MESSAGE_ADD_CAR_SUCCESS, validPerson.getName(), validCar.getVrn()),
+                commandResult.getFeedbackToUser());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddCarCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCarCommandTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
@@ -49,15 +50,15 @@ public class AddCarCommandTest {
 
         // Build the expected message after adding the car
         // The value 1 is passed to the string here as we know that the test only has 1 person inside the test stub.
-        String expectedMessage = String.format(AddCarCommand.MESSAGE_ADD_CAR_SUCCESS,
-                "1", validCar.getVrn(), validCar.getVin(),
-                validCar.getCarMake(), validCar.getCarModel());
+        Person validPersonWithCar = new PersonBuilder()
+                .withCar("SJH9514P", "KMHGH4JH3EU073801", "Toyota", "Corolla").build();
+        String expectedMessage = Messages.formatSuccessMessage(validPersonWithCar,
+                AddCarCommand.MESSAGE_ADD_CAR_SUCCESS);
 
         // Execute the command and capture the result
         CommandResult commandResult = addCarCommand.execute(modelStub);
 
-        assertEquals(String.format(AddCarCommand.MESSAGE_ADD_CAR_SUCCESS, validPerson.getName(), validCar.getVrn()),
-                commandResult.getFeedbackToUser());
+        assertEquals(expectedMessage, commandResult.getFeedbackToUser());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddClientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddClientCommandTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
@@ -40,7 +41,7 @@ public class AddClientCommandTest {
 
         CommandResult commandResult = new AddClientCommand(validPerson).execute(modelStub);
 
-        assertEquals(String.format(AddClientCommand.MESSAGE_SUCCESS, validPerson.getName()),
+        assertEquals(Messages.formatSuccessMessage(validPerson, AddClientCommand.MESSAGE_SUCCESS),
                 commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
     }

--- a/src/test/java/seedu/address/logic/commands/AddClientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddClientCommandTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
@@ -41,7 +40,7 @@ public class AddClientCommandTest {
 
         CommandResult commandResult = new AddClientCommand(validPerson).execute(modelStub);
 
-        assertEquals(String.format(AddClientCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
+        assertEquals(String.format(AddClientCommand.MESSAGE_SUCCESS, validPerson.getName()),
                 commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBookSomeWit
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -39,8 +40,8 @@ public class AddCommandIntegrationTest {
         expectedModel.addPerson(validPerson);
 
         assertCommandSuccess(new AddClientCommand(validPerson), model,
-                String.format(AddClientCommand.MESSAGE_SUCCESS, validPerson.getName()),
-                expectedModel);
+                Messages.formatSuccessMessage(validPerson, AddClientCommand.MESSAGE_SUCCESS),
+                        expectedModel);
     }
 
     @Test
@@ -61,7 +62,7 @@ public class AddCommandIntegrationTest {
         expectedModel.addPerson(validPerson);
 
         assertCommandSuccess(new AddClientCommand(validPerson), model,
-                String.format(AddClientCommand.MESSAGE_SUCCESS_WITH_CAR, validPerson.getName(), validPerson.getVrn()),
+                Messages.formatSuccessMessage(validPerson, AddClientCommand.MESSAGE_SUCCESS),
                         expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -10,7 +10,6 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBookSomeWit
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -40,7 +39,7 @@ public class AddCommandIntegrationTest {
         expectedModel.addPerson(validPerson);
 
         assertCommandSuccess(new AddClientCommand(validPerson), model,
-                String.format(AddClientCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
+                String.format(AddClientCommand.MESSAGE_SUCCESS, validPerson.getName()),
                 expectedModel);
     }
 
@@ -62,9 +61,8 @@ public class AddCommandIntegrationTest {
         expectedModel.addPerson(validPerson);
 
         assertCommandSuccess(new AddClientCommand(validPerson), model,
-                String.format(AddClientCommand.MESSAGE_SUCCESS, Messages.format(validPerson)
-                        + AddClientCommand.MESSAGE_SUCCESS_WITH_CAR + Messages.formatCar(validPerson)),
-                expectedModel);
+                String.format(AddClientCommand.MESSAGE_SUCCESS_WITH_CAR, validPerson.getName(), validPerson.getVrn()),
+                        expectedModel);
     }
 
     @Test
@@ -73,13 +71,13 @@ public class AddCommandIntegrationTest {
         Person personWithCar = new PersonBuilder()
                 .withCar("SH8942L", VALID_CAR_VIN_A, "Toyota", "Corolla").build();
         assertCommandFailure(new AddClientCommand(personWithCar), modelWithCar,
-                "This car already exists in the address book");
+                "Car already exists in MATER.");
 
         // One Person in the list has a car with the same VRN
         personWithCar = new PersonBuilder()
                 .withCar(VALID_CAR_VRN_A, "33333333333333333", "Toyota", "Corolla").build();
         assertCommandFailure(new AddClientCommand(personWithCar), modelWithCar,
-                "This car already exists in the address book");
+                "Car already exists in MATER.");
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/CheckClientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CheckClientCommandTest.java
@@ -37,19 +37,19 @@ public class CheckClientCommandTest {
      * @param index The index of the client to Check in/ out.
      */
     public void checkClientTestHelper(Person clientToCheck, Index index) {
-        CommandResult expectedCheckInResult = new CommandResult(
-                String.format(CheckClientCommand.MESSAGE_CHECK_IN_CLIENT_SUCCESS,
-                Messages.format(clientToCheck)));
-        CommandResult expectedCheckOutResult = new CommandResult(
-                String.format(CheckClientCommand.MESSAGE_CHECK_OUT_CLIENT_SUCCESS,
-                Messages.format(clientToCheck)));
-
         CheckClientCommand checkClientCommand = new CheckClientCommand(index);
         try {
             if (clientToCheck.getCar() == null) {
                 assertEquals(expectedNoCarToCheckMessage, checkClientCommand.execute(model));
                 return;
             }
+            CommandResult expectedCheckInResult = new CommandResult(
+                    String.format(CheckClientCommand.MESSAGE_CHECK_IN_CLIENT_SUCCESS,
+                    clientToCheck.getName(), clientToCheck.getVrn()));
+            CommandResult expectedCheckOutResult = new CommandResult(
+                    String.format(CheckClientCommand.MESSAGE_CHECK_OUT_CLIENT_SUCCESS,
+                    clientToCheck.getName(), clientToCheck.getVrn()));
+
             clientToCheck.setServicing();
             if (clientToCheck.isServicing()) {
                 assertEquals(expectedCheckInResult, checkClientCommand.execute(model));

--- a/src/test/java/seedu/address/logic/commands/DeleteCarCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCarCommandTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -42,12 +43,13 @@ public class DeleteCarCommandTest {
         // Step 4: Build the expected message for a successful car deletion
         // The value 1 is passed to the string here as we know that the test only has 1 person inside the test stub.
         Car carToDelete = personWithCar.getCar();
-        String expectedMessage = String.format(DeleteCarCommand.MESSAGE_DELETE_CAR_SUCCESS,
-                "1", carToDelete.getVrn(), carToDelete.getVin(),
-                carToDelete.getCarMake(), carToDelete.getCarModel());
 
         // Step 5: Execute the command and check for successful deletion
         CommandResult commandResult = deleteCarCommand.execute(modelStub);
+
+        Person personWithoutCar = new PersonBuilder().build();
+        String expectedMessage = Messages.formatSuccessMessage(personWithoutCar,
+                DeleteCarCommand.MESSAGE_DELETE_CAR_SUCCESS);
 
         // Step 6: Check the expected result and ensure no car remains
         assertEquals(expectedMessage, commandResult.getFeedbackToUser());

--- a/src/test/java/seedu/address/logic/commands/DeleteClientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteClientCommandTest.java
@@ -32,8 +32,8 @@ public class DeleteClientCommandTest {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteClientCommand deleteClientCommand = new DeleteClientCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteClientCommand.MESSAGE_DELETE_PERSON_SUCCESS,
-                Messages.format(personToDelete));
+        String expectedMessage = String.format(DeleteClientCommand.MESSAGE_DELETE_CLIENT_SUCCESS,
+                personToDelete.getName());
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -56,8 +56,8 @@ public class DeleteClientCommandTest {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteClientCommand deleteClientCommand = new DeleteClientCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteClientCommand.MESSAGE_DELETE_PERSON_SUCCESS,
-                Messages.format(personToDelete));
+        String expectedMessage = String.format(DeleteClientCommand.MESSAGE_DELETE_CLIENT_SUCCESS,
+                personToDelete.getName());
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);

--- a/src/test/java/seedu/address/logic/commands/DeleteClientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteClientCommandTest.java
@@ -32,8 +32,8 @@ public class DeleteClientCommandTest {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteClientCommand deleteClientCommand = new DeleteClientCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteClientCommand.MESSAGE_DELETE_CLIENT_SUCCESS,
-                personToDelete.getName());
+        String expectedMessage = Messages.formatSuccessMessage(personToDelete,
+                DeleteClientCommand.MESSAGE_DELETE_CLIENT_SUCCESS);
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -56,8 +56,8 @@ public class DeleteClientCommandTest {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteClientCommand deleteClientCommand = new DeleteClientCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteClientCommand.MESSAGE_DELETE_CLIENT_SUCCESS,
-                personToDelete.getName());
+        String expectedMessage = Messages.formatSuccessMessage(personToDelete,
+                DeleteClientCommand.MESSAGE_DELETE_CLIENT_SUCCESS);
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);

--- a/src/test/java/seedu/address/logic/commands/EditClientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditClientCommandTest.java
@@ -53,8 +53,8 @@ public class EditClientCommandTest {
             editPersonDescriptor, editCarDescriptor,
             true, false);
 
-        String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS,
-                editedPerson.getName());
+        String expectedMessage = Messages.formatSuccessMessage(editedPerson,
+                EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS);
 
         Model expectedModel = new ModelManager(new AddressBook(modelWithoutCar.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(modelWithoutCar.getFilteredPersonList().get(0), editedPerson);
@@ -75,8 +75,8 @@ public class EditClientCommandTest {
         EditClientCommand editClientCommand = new EditClientCommand(
                 indexLastPerson, descriptor, new EditCarDescriptor(), true, false);
 
-        String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS_WITH_CAR,
-                editedPerson.getName(), editedPerson.getVrn());
+        String expectedMessage = Messages.formatSuccessMessage(editedPerson,
+                EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(lastPerson, editedPerson);
@@ -91,10 +91,10 @@ public class EditClientCommandTest {
             new EditCarDescriptor(),
             false, false);
         Person editedPerson = model.getFilteredPersonList()
-            .get(INDEX_FIRST_PERSON.getZeroBased());
+                .get(INDEX_FIRST_PERSON.getZeroBased());
 
-        String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS_WITH_CAR,
-                editedPerson.getName(), editedPerson.getVrn());
+        String expectedMessage = Messages.formatSuccessMessage(editedPerson,
+                EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
@@ -111,8 +111,8 @@ public class EditClientCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_RACHEL).build(),
                 new EditCarDescriptor(), true, false);
 
-        String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS_WITH_CAR,
-                editedPerson.getName(), editedPerson.getVrn());
+        String expectedMessage = Messages.formatSuccessMessage(editedPerson,
+                EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
@@ -169,8 +169,7 @@ public class EditClientCommandTest {
 
         EditClientCommand editClientCommand = new EditClientCommand(outOfBoundIndex,
                 new EditPersonDescriptorBuilder()
-                    .withName(VALID_NAME_BOB).build(), new EditCarDescriptor(),
-                    true, false);
+                        .withName(VALID_NAME_BOB).build(), new EditCarDescriptor(), true, false);
 
         assertCommandFailure(editClientCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }

--- a/src/test/java/seedu/address/logic/commands/EditClientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditClientCommandTest.java
@@ -53,8 +53,8 @@ public class EditClientCommandTest {
             editPersonDescriptor, editCarDescriptor,
             true, false);
 
-        String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_PERSON_SUCCESS,
-            Messages.format(editedPerson));
+        String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS,
+                editedPerson.getName());
 
         Model expectedModel = new ModelManager(new AddressBook(modelWithoutCar.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(modelWithoutCar.getFilteredPersonList().get(0), editedPerson);
@@ -75,8 +75,8 @@ public class EditClientCommandTest {
         EditClientCommand editClientCommand = new EditClientCommand(
                 indexLastPerson, descriptor, new EditCarDescriptor(), true, false);
 
-        String expectedMessage = String.format(
-                EditClientCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS_WITH_CAR,
+                editedPerson.getName(), editedPerson.getVrn());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(lastPerson, editedPerson);
@@ -93,8 +93,8 @@ public class EditClientCommandTest {
         Person editedPerson = model.getFilteredPersonList()
             .get(INDEX_FIRST_PERSON.getZeroBased());
 
-        String expectedMessage = String.format(
-                EditClientCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS_WITH_CAR,
+                editedPerson.getName(), editedPerson.getVrn());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
@@ -111,8 +111,8 @@ public class EditClientCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_RACHEL).build(),
                 new EditCarDescriptor(), true, false);
 
-        String expectedMessage = String.format(
-                EditClientCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS_WITH_CAR,
+                editedPerson.getName(), editedPerson.getVrn());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);

--- a/src/test/java/seedu/address/logic/commands/ViewClientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewClientCommandTest.java
@@ -25,14 +25,7 @@ public class ViewClientCommandTest {
     public void execute_validIndexUnfilteredList_success() {
         Person personToView = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         ViewClientCommand viewClientCommand = new ViewClientCommand(INDEX_FIRST_PERSON);
-        String carDetails = personToView.getCar() == null ? "No car details available" : "VRN: "
-                + personToView.getCar().getVrn() + "\nVIN: " + personToView.getCar().getVin() + "\nMake: "
-                + personToView.getCar().getCarMake() + "\nModel: " + personToView.getCar().getCarModel();
-        String expectedMessage = String.format(ViewClientCommand.MESSAGE_SUCCESS,
-                personToView.getName(),
-                personToView.getPhone(), personToView.getEmail(),
-                personToView.getAddress(),
-                carDetails);
+        String expectedMessage = String.format(ViewClientCommand.MESSAGE_VIEW_CLIENT_SUCCESS, personToView.getName());
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         CommandResult expectedCommandResult = new CommandResult(
             expectedMessage, false, false, true, personToView

--- a/src/test/java/seedu/address/logic/commands/ViewClientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewClientCommandTest.java
@@ -25,7 +25,8 @@ public class ViewClientCommandTest {
     public void execute_validIndexUnfilteredList_success() {
         Person personToView = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         ViewClientCommand viewClientCommand = new ViewClientCommand(INDEX_FIRST_PERSON);
-        String expectedMessage = String.format(ViewClientCommand.MESSAGE_VIEW_CLIENT_SUCCESS, personToView.getName());
+        String expectedMessage = Messages.formatSuccessMessage(personToView,
+                ViewClientCommand.MESSAGE_VIEW_CLIENT_SUCCESS);
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         CommandResult expectedCommandResult = new CommandResult(
             expectedMessage, false, false, true, personToView


### PR DESCRIPTION
Fixes #129 
Fixes #131 

## Wrap texts in Result Display, eliminate the need to scroll left and right.
<img width="651" alt="Screenshot 2024-10-25 at 1 02 40 AM" src="https://github.com/user-attachments/assets/f3395625-5432-48e9-8b97-352341a5984e">

## Shorten Success Messages
### With Car (Show Name and VRN).
<img width="653" alt="Screenshot 2024-10-25 at 1 02 57 AM" src="https://github.com/user-attachments/assets/4824d502-1621-4953-b62c-d3f943b94cd6">

<bold>Note: Whitespace between Name and (VRN: ) added after screenshot was taken.</bold>

### With No Car (Show Name only).
<img width="651" alt="Screenshot 2024-10-25 at 1 03 11 AM" src="https://github.com/user-attachments/assets/6eb9df94-8f27-411d-a16a-23185baddf3b">