### PR TITLE
Fix Delete Car Bug

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -491,20 +491,20 @@ Parameter | Requirements | Explanation
 
 <h3 style="color: #1877F2;">Saving the Data</h3>
 
-MATER data are saved automatically in the hard disk after any command that changes the data. There is no need to save manually.
+MATER's data is saved automatically in the hard disk after any command that changes its data. There is no need to save data manually.
 
 ---
 
 <h3 style="color: #1877F2;">Editing the Data File</h3>
 
-MATER data are saved automatically as a JSON file at `[JAR file location]/data/addressbook.json`. Advanced users are welcome to update data directly by editing this data file.
+MATER's data is saved automatically as a JSON file at `[JAR file location]/data/addressbook.json`. Advanced users are welcome to update data directly by editing this data file.
 
 <box type="warning" seamless>
 
 **Caution: FOR EXPERT USERS ONLY**
 
-- If your changes to the data file make its format invalid, MATER will discard all data and start with an empty data file at the next run. It is recommended to take a backup of the file before editing it.
-- Certain edits can cause the MATER to behave in unexpected ways (e.g., if a value entered is outside the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
+- If your changes to the data file make its format invalid, MATER will discard all data and start with an empty data file at the next run. It is strongly recommended to create a backup of the file before editing it.
+- Certain edits can cause MATER to behave in unexpected ways (e.g., if a value entered is outside the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
 
 </box>
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCarCommand.java
@@ -2,18 +2,26 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.issue.Issue;
 import seedu.address.model.person.Person;
 
 /**
  * Deletes a Car belonging to a person already present in the MATER address book.
  */
 public class DeleteCarCommand extends Command {
+
+
+    // This initializes an empty set of issues to pass into the updated person slot.
+    // It only makes sense that when a car is deleted from MATER, its issues would also not be recorded anymore.
+    public static final Set<Issue> blankSlate = Collections.emptySet();
 
     public static final String COMMAND_WORD = "del-car";
 
@@ -66,7 +74,7 @@ public class DeleteCarCommand extends Command {
                 personToDeleteCarFrom.getPhone(),
                 personToDeleteCarFrom.getEmail(),
                 personToDeleteCarFrom.getAddress(),
-                personToDeleteCarFrom.getIssues()
+                blankSlate
         );
 
         // This method call effectively replaces the old user with the new user with a car.


### PR DESCRIPTION
Introduces a static variable for an empty Set<Issue> and creates a new Person object with this empty set in order to prevent issues from coming back from the grave after a new car is added.

Do tell me if you have any other suggestions for alternative implementations. I went for the smallest-scope/not-reliant-on-edit-car solution.