### PR TITLE
[Bug Fix] add-client Null Issue handling

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddClientCommand.java
@@ -52,6 +52,7 @@ public class AddClientCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New Client added to MATER";
     public static final String MESSAGE_DUPLICATE_PERSON = "Client already exists in MATER.";
     public static final String MESSAGE_NO_CAR_TO_ADD_ISSUES = "Client does not have a Car to add Issues.";
+    public static final String MESSAGE_DUPLICATE_CAR = "Car already exists in MATER.";
 
     private final Person toAdd;
 
@@ -72,7 +73,7 @@ public class AddClientCommand extends Command {
         }
 
         if (model.hasCar(toAdd.getCar())) {
-            throw new CommandException("Car already exists in MATER.");
+            throw new CommandException(MESSAGE_DUPLICATE_CAR);
         }
 
         // Check if there is a Car to add Issues to.

--- a/src/main/java/seedu/address/logic/parser/AddClientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddClientCommandParser.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VIN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VRN;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -61,10 +62,11 @@ public class AddClientCommandParser implements Parser<AddClientCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
-        Set<Issue> issueList = ParserUtil.parseIssues(argMultimap.getAllValues(PREFIX_ISSUE));
         Person person;
 
+        // If Client has a Car. Issues also can be added to it, if any.
         if (isCarPresent) {
+            Set<Issue> issueList = ParserUtil.parseIssues(argMultimap.getAllValues(PREFIX_ISSUE));
             System.out.println("Car is present" + argMultimap.getValue(PREFIX_VRN).get());
             argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_VRN, PREFIX_VIN, PREFIX_MAKE, PREFIX_MODEL);
             String vrn = argMultimap.getValue(PREFIX_VRN).orElse("");
@@ -72,12 +74,19 @@ public class AddClientCommandParser implements Parser<AddClientCommand> {
             String make = argMultimap.getValue(PREFIX_MAKE).orElse("");
             String model = argMultimap.getValue(PREFIX_MODEL).orElse("");
 
+            // Create Car and Issues.
             Car car = ParserUtil.parseCar(vrn, vin, make, model);
             person = new Person(name, phone, email, address, issueList, car);
-        } else {
-            person = new Person(name, phone, email, address, issueList);
+            return new AddClientCommand(person);
         }
 
+        // If Client does not have a Car, but user tries to add issues to it.
+        if (arePrefixesPresent(argMultimap, PREFIX_ISSUE)) {
+            throw new ParseException(AddClientCommand.MESSAGE_NO_CAR_TO_ADD_ISSUES);
+        }
+
+        // If Client does not have a Car, and user does not try to add issues to it.
+        person = new Person(name, phone, email, address, new HashSet<>());
         return new AddClientCommand(person);
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -83,6 +83,9 @@ public class CommandTestUtil {
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_ISSUE_DESC = " " + PREFIX_ISSUE + "hubby*"; // '*' not allowed in issues
 
+    // Client without Car should not a request to add have Issue.
+    public static final String EMPTY_ISSUE_DESC = " " + PREFIX_ISSUE;
+
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 

--- a/src/test/java/seedu/address/logic/parser/AddClientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddClientCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.CAR_DESC_B;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMPTY_ISSUE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ISSUE_DESC;
@@ -51,7 +52,6 @@ import seedu.address.model.car.CarMake;
 import seedu.address.model.car.CarModel;
 import seedu.address.model.car.Vin;
 import seedu.address.model.car.Vrn;
-import seedu.address.model.issue.Issue;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -68,17 +68,19 @@ public class AddClientCommandParserTest {
         Person expectedPerson = new PersonBuilder(BOB).withIssues(VALID_ISSUE_FRIEND).build();
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + ISSUE_DESC_FRIEND, new AddClientCommand(expectedPerson));
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                + ADDRESS_DESC_BOB + ISSUE_DESC_FRIEND, AddClientCommand.MESSAGE_NO_CAR_TO_ADD_ISSUES);
 
+        // i/ but no issue
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+            + ADDRESS_DESC_BOB + EMPTY_ISSUE_DESC, AddClientCommand.MESSAGE_NO_CAR_TO_ADD_ISSUES);
 
         // multiple issues - all accepted
         Person expectedPersonMultipleIssues = new PersonBuilder(BOB).withIssues(VALID_ISSUE_FRIEND, VALID_ISSUE_HUSBAND)
                 .build();
-        assertParseSuccess(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + ISSUE_DESC_HUSBAND + ISSUE_DESC_FRIEND,
-                new AddClientCommand(expectedPersonMultipleIssues));
+                AddClientCommand.MESSAGE_NO_CAR_TO_ADD_ISSUES);
     }
 
     /*
@@ -281,7 +283,7 @@ public class AddClientCommandParserTest {
 
         // invalid issue
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_ISSUE_DESC + VALID_ISSUE_FRIEND, Issue.MESSAGE_CONSTRAINTS);
+                + INVALID_ISSUE_DESC + VALID_ISSUE_FRIEND, AddClientCommand.MESSAGE_NO_CAR_TO_ADD_ISSUES);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,


### PR DESCRIPTION
Fixes #236 
### Fixed behaviour for Client with NO Car and Null Issue.
<img width="584" alt="Screenshot 2024-11-09 at 7 41 37 PM" src="https://github.com/user-attachments/assets/c0a0750c-d54a-4ab6-9574-d6919a5a85b7">

# Regression Testing Below
### Client with NO Car and NO Issue.
<img width="585" alt="Screenshot 2024-11-09 at 7 46 31 PM" src="https://github.com/user-attachments/assets/3ceb28b0-6183-4f9f-bda9-f9fb7edec422">

### Client with NO Car and valid Issue.
<img width="586" alt="Screenshot 2024-11-09 at 7 41 24 PM" src="https://github.com/user-attachments/assets/7f19a606-fd89-4139-b056-2e9f5380b0b4">

### Client with Car and NO Issue.
<img width="584" alt="Screenshot 2024-11-09 at 7 43 37 PM" src="https://github.com/user-attachments/assets/91338de6-8be4-482c-99fb-4a5f717a79b9">

### Client with Car and Null Issue.
<img width="583" alt="Screenshot 2024-11-09 at 7 44 50 PM" src="https://github.com/user-attachments/assets/ff69ecec-0617-49bd-979f-294ec2767007">

### Client with Car and Issues.
<img width="589" alt="Screenshot 2024-11-09 at 7 45 39 PM" src="https://github.com/user-attachments/assets/21407928-ac10-4335-910e-2bba1d15fad2">
